### PR TITLE
Only attempt to update docker containers in service dirs

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -6,9 +6,10 @@
 
 set -e
 
-for d in /opt/infra/*/; do (
-        cd $d
+for service in demo docs setup traefik ; do (
+        pushd /opt/infra/$service/
         docker-compose pull
         docker-compose up -d
+        popd
         )
 done


### PR DESCRIPTION
i.e., skip the ssh dir since docker-compose will fail since no
composefile is present. This up until now lead to traefik never getting
updated …