### PR TITLE
Prune unused dangling images after update

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -13,3 +13,5 @@ for service in demo docs setup traefik ; do (
         popd
         )
 done
+
+docker image prune -f


### PR DESCRIPTION
Currently, the setup instance will fill up its `/` because the leftover
outdated docker images are kept around.

While this fix is a bit harsh, it will solve the problem for now, and
not immediately bite us. This is because all images we potentially prune
are still available (probably for a long time) from docker-hub, so
rolling back should be possible if needed.