### PR TITLE
Fix reset.sh really resetting the deployment

### DIFF
--- a/demo/reset.sh
+++ b/demo/reset.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+rm -rf /mailu
 cd /opt/infra/demo
 /usr/local/bin/docker-compose down || exit 1
 rm -rf /mailu


### PR DESCRIPTION
I already fixed this on the server itself. 
Now I will follow proper procedures by doing it via this pull request.

On the server I will undo the change (git checkout -- *) and will pull the updated file again via git pull.

Description:
The reset.sh script did not delete the mailu folder. As a result the old database was still reused. This lead to the situation where the password cannot be reset for the admin user and all other configuration was not reset.