### PR TITLE
fixed reset of admin account password

### DIFF
--- a/demo/.env
+++ b/demo/.env
@@ -152,3 +152,9 @@ REAL_IP_FROM=
 
 # choose wether mailu bounces (no) or rejects (yes) mail when recipient is unknown (value: yes, no)
 REJECT_UNLISTED_RECIPIENT=
+
+# initial admin account for demo
+INITIAL_ADMIN_ACCOUNT=admin
+INITIAL_ADMIN_DOMAIN=test.mailu.io
+INITIAL_ADMIN_PW=letmein
+INITIAL_ADMIN_MODE=update

--- a/demo/admin-pw.sh
+++ b/demo/admin-pw.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd /opt/infra/demo
-/usr/local/bin/docker-compose exec admin flask mailu password admin test.mailu.io letmein >/dev/null
+/usr/local/bin/docker-compose exec admin flask mailu admin --mode update admin test.mailu.io letmein >/dev/null

--- a/demo/admin-pw.sh
+++ b/demo/admin-pw.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd /opt/infra/demo
-/usr/local/bin/docker-compose exec -d admin flask mailu password admin test.mailu.io letmein
+/usr/local/bin/docker-compose exec admin flask mailu password admin test.mailu.io letmein >/dev/null

--- a/demo/reset.sh
+++ b/demo/reset.sh
@@ -4,5 +4,3 @@ cd /opt/infra/demo
 /usr/local/bin/docker-compose down || exit 1
 rm -rf /mailu
 /usr/local/bin/docker-compose up -d || exit 1
-sleep 30
-/usr/local/bin/docker-compose exec -d admin flask mailu admin admin test.mailu.io letmein || exit 1


### PR DESCRIPTION
- set via INITIAL_ADMIN_* on update and on reset
- admin-pw.sh: set without -d to log errors
- admin-pw.sh: use 'admin' command to re-create admin if deleted