### PR TITLE
Update scripts to use 'docker compose' and update the admin password.

### DIFF
--- a/demo/admin-pw.sh
+++ b/demo/admin-pw.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd /opt/infra/demo
-/usr/local/bin/docker-compose exec admin flask mailu admin --mode update admin test.mailu.io letmein >/dev/null
+/usr/bin/docker compose exec admin flask mailu admin --mode update admin test.mailu.io MailuDemo >/dev/null

--- a/demo/reset.sh
+++ b/demo/reset.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 rm -rf /mailu
 cd /opt/infra/demo
-/usr/local/bin/docker-compose down || exit 1
+/usr/bin/docker compose down || exit 1
 rm -rf /mailu
-/usr/local/bin/docker-compose up -d || exit 1
+/usr/bin/docker compose up -d || exit 1

--- a/update.sh
+++ b/update.sh
@@ -8,8 +8,8 @@ set -e
 
 for service in demo docs setup traefik ; do (
         pushd /opt/infra/$service/
-        docker-compose pull
-        docker-compose up -d
+        /usr/bin/docker compose pull
+        /usr/bin/docker compose up -d
         popd
         )
 done


### PR DESCRIPTION
Docker has been fully updated. Instead of the deprecated docker-compose executable the docker compose plugin is used now.
AS discussed in #27, the password must be updated. As soon as this is merged, I will work on a PR for the documentation.