### PR TITLE
Correctly format IPv6 address

### DIFF
--- a/demo/.env
+++ b/demo/.env
@@ -18,7 +18,7 @@ SECRET_KEY=ZuwuN9iogh9aec2i
 
 # Address where listening ports should bind
 BIND_ADDRESS4=78.47.92.244
-BIND_ADDRESS6=2a01:4f8:c2c:f707::1
+BIND_ADDRESS6=[2a01:4f8:c2c:f707::1]
 
 # Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
 SUBNET=192.168.203.0/24


### PR DESCRIPTION
Added square brackets. The current version of Docker compose requires this in the docker-compose.yml file.